### PR TITLE
include logging info for opened Obsid

### DIFF
--- a/cus_app/chkupdata/routes.py
+++ b/cus_app/chkupdata/routes.py
@@ -86,6 +86,7 @@ def before_request():
 @bp.route('/<name>',       methods=['GET', 'POST'])
 @bp.route('/index/<name>', methods=['GET', 'POST'])
 def index(name=''):
+    current_app.logger.info(f"Opening Obsid.Rev: {name}")
 #
 #--- initialize
 #

--- a/cus_app/ocatdatapage/routes.py
+++ b/cus_app/ocatdatapage/routes.py
@@ -98,7 +98,7 @@ def before_request():
 @bp.route('/<obsid>',       methods=['GET', 'POST'])
 @bp.route('/index/<obsid>', methods=['GET', 'POST'])
 def index(obsid=''):
-
+    current_app.logger.info(f"Opening Obsid: {obsid}")
     form     = OcatParamForm()
 #
 #--- check an obsid given is in a proper form


### PR DESCRIPTION
Adds logging commands to record the obsid when opening the ocat data page and record the obsid.rev when opening the chkupdata page. This does not change the user interface but provides a log for error emails if a specific osbid or specific obsid.rev has an edge can which throws an error. This will pass through the coat.log files and admins will receive this info as part of the Usint Error emails.