### PR TITLE
Fix user database

### DIFF
--- a/update_user_database.py
+++ b/update_user_database.py
@@ -38,13 +38,13 @@ def update_user_database():
                 id INT PRIMARY KEY NOT NULL,
                 username string(64) NOT NULL,
                 email string(64) NOT NULL,
-                group_string string(64) NOT NULL);"""
+                groups_string string(64) NOT NULL);"""
     
     cur.execute(table)
     #Test user in ID 0
     cur.execute(f"INSERT INTO User VALUES ('0', 'testUSINT', '{ADMIN}', 'test');")
     for user, info in users_dict.items():
-        cur.execute(f"INSERT INTO User VALUES ('{info['id']}', '{user}', '{info['email']}', '{info['group_string']}');")
+        cur.execute(f"INSERT INTO User VALUES ('{info['id']}', '{user}', '{info['email']}', '{info['groups_string']}');")
     con.commit()
 
 def read_groups(ifile = IFILE):
@@ -66,19 +66,19 @@ def read_groups(ifile = IFILE):
         for member in member_subset:
             if member not in users_dict.keys():
                 #Unlisted member
-                users_dict[member] = {'id': k, 'group_string': group}
+                users_dict[member] = {'id': k, 'groups_string': group}
                 k += 1
             else:
                 #Listed member
-                users_dict[member]['group_string'] += f":{group}"
+                users_dict[member]['groups_string'] += f":{group}"
     
     return users_dict
 
 def find_email(users_dict):
     """
     Input a email found trhough the getent command into a users information dictionary
-    input: users_dict --- users dictionary keyed by username and values with id and group_string
-    output: users_dict --- users dictionary keyed by username and values with id and group_string and email
+    input: users_dict --- users dictionary keyed by username and values with id and groups_string
+    output: users_dict --- users dictionary keyed by username and values with id and groups_string and email
     """
 #
 #--- Read the NameSwitch Library Alias Database

--- a/update_user_database.py
+++ b/update_user_database.py
@@ -6,7 +6,7 @@ import argparse
 
 IFILE = "/data/mta4/CUS/www/.groups"
 OUT_DIR = "/data/mta4/CUS/Data/Users"
-
+ADMIN = 'william.aaron@cfa.harvard.edu'
 
 def update_user_database():
     """
@@ -41,9 +41,10 @@ def update_user_database():
                 group_string string(64) NOT NULL);"""
     
     cur.execute(table)
+    #Test user in ID 0
+    cur.execute(f"INSERT INTO User VALUES ('0', 'testUSINT', '{ADMIN}', 'test');")
     for user, info in users_dict.items():
-        cur.execute(f"INSERT INTO User VALUES ({info['id']}, {user}, {info['email']}, {info['group_string']})")
-
+        cur.execute(f"INSERT INTO User VALUES ('{info['id']}', '{user}', '{info['email']}', '{info['group_string']}');")
     con.commit()
 
 def read_groups(ifile = IFILE):
@@ -87,7 +88,6 @@ def find_email(users_dict):
     for ent in search:
         if ent[0] in users_dict.keys():
             users_dict[ent[0]]['email'] = ent[1].strip()
-    users_dict['testUSINT'] = {'id': 0, 'email': 'william.aaron@cfa.harvard.edu', 'group_string': 'test'}
     return users_dict
 
 


### PR DESCRIPTION
This PR addresses Issue #21 which prevented the Usint Users database from being edited/updated while still maintaining live usage of the website. Through restructuring the script for this purpose, better testing methods and data fetch efficiency has also been implemented.

Note for future reference and documentation. The USINT users SQLite3 database generator operates on the assumption that access to the website is authenticated with the LDAP module and that users are whitelisted in an LDAP .htgroups formatted file. If in future, the LDAP authentication measures are altered to some other setup, this script will need to be changed to adhere to that new authentication setup