### PR TITLE
Allow None for RA DEC

### DIFF
--- a/cus_app/ocatdatapage/check_value_range.py
+++ b/cus_app/ocatdatapage/check_value_range.py
@@ -115,7 +115,7 @@ def check_value_range(ct_dict):
 #--- check mutually-exclusive parameters values
 #
     for a_list in exclude_list:
-        note = check_exclusitity(a_list, ct_dict)
+        note = check_exclusivity(a_list, ct_dict)
         if note != '':
             warning_list.append(note)
      
@@ -173,10 +173,10 @@ def check_param_value(a_list, ct_dict, k=''):
     return c_list
 
 #-----------------------------------------------------------------------------------------------
-#-- check_exclusitity: check two exclusive parameters have the values at the same time        --
+#-- check_exclusivity: check two exclusive parameters have the values at the same time        --
 #-----------------------------------------------------------------------------------------------
 
-def check_exclusitity(a_list, ct_dict):
+def check_exclusivity(a_list, ct_dict):
     """
     check two exclusive parameters have the values at the same time.
     input:  ct_dict         --- a dict of <param> <---> <information>
@@ -231,20 +231,29 @@ def ra_dec_range_check(ct_dict, warning_list):
 #
     note    = ''
     if ra not in null_list and (ra < 0 or ra > 360):
-        note = 'The value of RA is out of range. Please check the value.\n'
+        note += 'The value of RA is out of range. Please check the value.\n'
 
     if dec not in null_list and (dec < -90 or dec > 90):
-        note = 'The value of Dec is out of range. Please check the value.\n'
+        note += 'The value of Dec is out of range. Please check the value.\n'
+#
+#--- check if ra, dec has been nullified
+#
+    if note == '':
+        if ra in null_list and ora not in null_list:
+            note += 'The value of RA has been nullified. Please check the value.\n'
+        if dec in null_list and odec not in null_list:
+            note += 'The value of DEC has been nullified. Please check the value.\n'
+
 #
 #--- check whether there is a large coordindate shift
 #
     if note == '':
-        try:
+        if (ora in null_list) and (ra not in null_list) and (odec in null_list) and (dec not in null_list):
+            note += 'Coordinates have been defined. You need a CDO permission.\n'
+        else:
             diff      = math.sqrt((ora -ra)**2 + (odec - dec)**2)
             if diff > 0.1333:
-                note = 'The coordinates were shifted more than 8 arcmin. You need a CDO permssion.\n'
-        except:
-            pass
+                note += 'The coordinates were shifted more than 8 arcmin. You need a CDO permssion.\n'
 
     if note != '':
         warning_list.append(note)
@@ -267,7 +276,7 @@ def frame_time_check(ct_dict, warning_list):
     """
     inst = ct_dict['instrument'][-1]
     if inst in ['ACIS-I', 'ACIS-S']: 
-        note = check_exclusitity(['frame_time', 'most_efficient'], ct_dict)
+        note = check_exclusivity(['frame_time', 'most_efficient'], ct_dict)
         warning_list.append(note)
 
     return warning_list

--- a/cus_app/ocatdatapage/check_value_range.py
+++ b/cus_app/ocatdatapage/check_value_range.py
@@ -216,26 +216,35 @@ def ra_dec_range_check(ct_dict, warning_list):
     dra       = ct_dict['dra'][-1]
     ddec      = ct_dict['ddec'][-1]
     ra, dec   = ocf.convert_ra_dec_format(dra, ddec)
-    ora       = float(ora)
-    odec      = float(odec)
-    ra        = float(ra)
-    dec       = float(dec)
+    #If ra, dec is in the null_list (TOO), then return no warning
+    #Convert to floats for calculation purposes
+    coords = [ora, odec, ra, dec]
+    for i in range(len(coords)):
+        if coords[i] not in null_list:
+            coords[i] = float(coords[i])
+    ora = coords[0]
+    odec = coords[1]
+    ra = coords[2]
+    dec = coords[3]
 #
 #--- checking ra and dec values are in expected ranges
 #
     note    = ''
-    if ra < 0 or ra > 360:
+    if ra not in null_list and (ra < 0 or ra > 360):
         note = 'The value of RA is out of range. Please check the value.\n'
 
-    if dec < -90 or dec > 90:
+    if dec not in null_list and (dec < -90 or dec > 90):
         note = 'The value of Dec is out of range. Please check the value.\n'
 #
 #--- check whether there is a large coordindate shift
 #
     if note == '':
-        diff      = math.sqrt((ora -ra)**2 + (odec - dec)**2)
-        if diff > 0.1333:
-            note = 'The coordindated was shifted more than 8 arcmin. You need a CDO permssion.\n'
+        try:
+            diff      = math.sqrt((ora -ra)**2 + (odec - dec)**2)
+            if diff > 0.1333:
+                note = 'The coordinates were shifted more than 8 arcmin. You need a CDO permssion.\n'
+        except:
+            pass
 
     if note != '':
         warning_list.append(note)

--- a/cus_app/ocatdatapage/create_selection_dict.py
+++ b/cus_app/ocatdatapage/create_selection_dict.py
@@ -94,7 +94,7 @@ def create_selection_dict(obsid):
     """
 #
 #--- get the values from the database
-#
+#   
     ct_dict = rod.read_ocat_data(obsid)
     p_dict  = {}
 #
@@ -345,7 +345,7 @@ def create_selection_dict(obsid):
     group        = 'gen'
     vals         = ct_dict[p_id]
     try:
-        vals     = f"{round(float(ra),6):3.6f}"
+        vals     = f"{round(float(vals),6):3.6f}"
     except:
         if vals not in null_list:
             #Invalid string
@@ -361,7 +361,7 @@ def create_selection_dict(obsid):
     group        = 'gen'
     vals         = ct_dict[p_id]
     try:
-        vals     = f"{round(float(ra),6):3.6f}"
+        vals     = f"{round(float(vals),6):3.6f}"
     except:
         if vals not in null_list:
             #Invalid string

--- a/cus_app/ocatdatapage/create_selection_dict.py
+++ b/cus_app/ocatdatapage/create_selection_dict.py
@@ -345,9 +345,12 @@ def create_selection_dict(obsid):
     group        = 'gen'
     vals         = ct_dict[p_id]
     try:
-        vals     = '%3.6f' % float(round(vals,6))
+        vals     = f"{round(float(ra),6):3.6f}"
     except:
-        vals     = '0.0'
+        if vals not in null_list:
+            #Invalid string
+            raise Exception(f"Fetched RA value invalid: {vals}")
+
     ra           = vals
     p_dict[p_id] = [label, choices, lind, group, vals, vals]
 
@@ -358,9 +361,11 @@ def create_selection_dict(obsid):
     group        = 'gen'
     vals         = ct_dict[p_id]
     try:
-        vals     = '%3.6f' % float(round(vals, 6))
+        vals     = f"{round(float(ra),6):3.6f}"
     except:
-        vals     = '0.0'
+        if vals not in null_list:
+            #Invalid string
+            raise Exception(f"Fetched DEC value invalid: {vals}")
     dec          = vals
     p_dict[p_id] = [label, choices, lind, group, vals, vals]
 #

--- a/cus_app/ocatdatapage/update_data_record_file.py
+++ b/cus_app/ocatdatapage/update_data_record_file.py
@@ -790,11 +790,18 @@ def check_coordinate_shift(ct_dict):
     input:  ct_dict --- a dict of <param> <--> <information>
     output: either <blank> or <obsid>
     """
-    ora  = float(ct_dict['ra'][-1])
-    nra  = float(ct_dict['ra'][-2])
-
-    odec = float(ct_dict['dec'][-1])
-    ndec = float(ct_dict['dec'][-2])
+    ora = ct_dict['ra'][-1]
+    nra = ct_dict['ra'][-2]
+    odec = ct_dict['dec'][-1]
+    ndec = ct_dict['dec'][-2]
+    if {ora, nra, odec, ndec}.intersection(set(null_list)):
+        #Contains a null_value (TOO), therefore no large shift by definition
+        return []
+    else:
+        ora = float(ora)
+        nra = float(nra)
+        odec = float(odec)
+        ndec = float(ndec)
 
     diff = math.sqrt((ora - nra)**2 + (odec - ndec)**2)
 

--- a/cus_app/supple/ocat_common_functions.py
+++ b/cus_app/supple/ocat_common_functions.py
@@ -44,6 +44,7 @@ for ent in data:
     line = atemp[0].strip()
     exec("%s = '%s'" %(var, line))
 """
+null_list   = ['','N', 'NO', 'NULL', 'NA', 'NONE', 'n', 'No', 'Null', 'Na', 'None', None]
 
 #---------------------------------------------------------------------------------
 #-- clean_text: intake a section of text and format for Unix file conventions   --
@@ -679,6 +680,8 @@ def convert_ra_dec_format(dra, ddec, format='switch'):
     output: tra     --- either <hh>:<mm>:<ss> or <dd.ddddd> format
             tdec    --- either <dd>:<mm>:<ss> or <ddd.ddddd> format
     """
+    if dra in null_list and ddec in null_list:
+        return dra, ddec
     #
     #--- Define output format
     #


### PR DESCRIPTION
This PR addresses Issue #44.

By default, the Usint software interprets the value of None in the Obscat database as zero when processing the RA, DEC parameter values. Therefore, when a revision is processed and the RA, DEC values for a TOO are registered as zero, this is understood by convention to mean that the observation RA, DEC values have yet to be determined, and when they are determined, it is typically more than 8 arcminutes away from 00:00:00-RA, +00:00:00-DEC which throws the CDO permission warning as necessary for determining the location of a TOO.

Now the Usint software is capable of retaining these null values as allowable value strings for the revisions files, and sends out alternative warnings to give more descriptive options for a specific observation scenario.