### PR TITLE
Correction to library pathing

### DIFF
--- a/other_scripts/create_schedule_table.py
+++ b/other_scripts/create_schedule_table.py
@@ -9,6 +9,9 @@
 #               last update: Jun 14, 2024                                                       #
 #                                                                                               #
 #################################################################################################
+import sys
+sys.path.append("/data/mta4/Script/Python3.11/lib/python3.11/site-packages")
+
 import os
 import time
 import Chandra.Time


### PR DESCRIPTION
This script was missing the pathing required for importing the dotenv library, and has now been included.

As a side note, the cronjob running as cus@r2d2-v has also been corrected to...
`3 0 * * * cd /data/mta4/CUS/www/Usint/; /proj/sot/ska3/flight/bin/skare ./create_schedule_table.py -m flight >> $HOME/Logs/too_contact.cron 2>&1`