### PR TITLE
Discard button

### DIFF
--- a/cus_app/orupdate/routes.py
+++ b/cus_app/orupdate/routes.py
@@ -582,7 +582,7 @@ def check_signoff(form, poc_dict, odata):
         mc4 = re.search('hrc',     key)
         mc5 = re.search('verify',  key)
         mc6 = re.search('approve', key)
-        mc7 = re.search('close',   key)
+        mc7 = re.search('discard',   key)
         chk = False
 #
 #--- general is signed off
@@ -644,7 +644,7 @@ def check_signoff(form, poc_dict, odata):
         elif mc7 is not None:
             obsidrev = get_obsidrev(key, form)
             if obsidrev != 0:
-                chk = update_data(obsidrev, 5, close=1)
+                chk = update_data(obsidrev, 5, discard=1)
 
     return chk
 
@@ -665,7 +665,7 @@ def get_obsidrev(key, form):
 #--- only when the data value exists, return <obsid>.<rev#>
 #
     ent = form[key]
-    if ent in ['Sign-off', 'Sign-off & Approve', 'Close']:
+    if ent in ['Sign-off', 'Sign-off & Approve', 'Discard']:
         atemp = re.split('_', key)
         obsidrev = atemp[-1]
     else: 
@@ -677,7 +677,7 @@ def get_obsidrev(key, form):
 #-- update_data: update <ocat_dir>/updates_table.list data file                   --
 #----------------------------------------------------------------------------------
 
-def update_data(obsidrev, pos, close=0):
+def update_data(obsidrev, pos, discard=0):
     """ 
     update <ocat_dir>/updates_table.list data file
     input:  obsidrev    --- <obsid>.<rev#>
@@ -690,7 +690,7 @@ def update_data(obsidrev, pos, close=0):
                             note: col 0 is <obsid>.<rev>
                                   col 6 is <seq #>
                                   col 7 is <poc id>
-            close       --- whehter close is asked or not 0/1 . 1: yes
+            discard       --- whether discard is asked or not 0/1 . 1: yes
     output: updated <ocat_dir>/updates_table.list
     """
     user     = current_user.username    
@@ -716,7 +716,7 @@ def update_data(obsidrev, pos, close=0):
                 cmd = 'cp  -f ' + ufile + ' ' + ufile + '~'
                 os.system(cmd)
 
-                line = create_data_line(data, obsidrev, pos, sign, close)
+                line = create_data_line(data, obsidrev, pos, sign, discard)
                 fo.write(line)
 
         return False
@@ -725,19 +725,19 @@ def update_data(obsidrev, pos, close=0):
 #-- create_data_line: create data line to print out                              --
 #----------------------------------------------------------------------------------
 
-def create_data_line(data, obsidrev, pos, sign, close):
+def create_data_line(data, obsidrev, pos, sign, discard):
     """
     create data line to print out
     input:  data        --- a list of data
             obsidreve   --- <obsid>.<rev #>
             pos         --- position of sign-off
             sign        --- <user name> <today's date>
-            close       --- 0/1. if 1, close all open sign-off
+            discard       --- 0/1. if 1, discard all open sign-off
     output: line        --- strings of output data
     """
     dlen     = len(data)
 #
-#--- reverse the data; assume that none-closed entries are at the close to the end 
+#--- reverse the data; assume that opened entries are close to the end 
 #
     data.reverse()
     for k in range(0, dlen):
@@ -748,7 +748,7 @@ def create_data_line(data, obsidrev, pos, sign, close):
 #
 #--- if closing is asked, fill opened column with 'N/A' (except verified column)
 #
-            if close > 0:
+            if discard > 0:
                 for m in range(1, 5):
                     if atemp[m] == 'NA':
                         atemp[m] = 'N/A'

--- a/cus_app/static/orupdate/help.html
+++ b/cus_app/static/orupdate/help.html
@@ -28,6 +28,7 @@ If there are multiple revisions of the same obsid on the list:
     If "<span style='color:darkorchid;'>Higher Rev # Was Already Signed Off</span>"
     is listed in the "Note column," the obsid has a newer entry already signed off. 
     Please verify all versions of the obsid on the table, as the latest one (which was already signed off) supersedes all previous revisions.
+    If an earlier version of the obsid contains unsigned edits which are no longer desired, consult the "Discard" button.
     </li>
     <li style='padding-bottom:10px;'>
     You can clear any "out-of-date" entries

--- a/cus_app/templates/orupdate/index.html
+++ b/cus_app/templates/orupdate/index.html
@@ -23,7 +23,7 @@
     <br/>The "Discard" button should be used to clear "out-of-date" entries from the Target Parameter Status Page by recording the unsigned columns as "N/A" in the database.
     </p>
     <p>
-    Any sign-off, verification, or discard action can be reversed by the user in the Remove Accidental Submission Page.
+    If caught early enough, any sign-off, verification, or discard action can be reversed by the user in the Remove Accidental Submission Page.
     </p>
 <!-- -->
 <!-- form start here -->

--- a/cus_app/templates/orupdate/index.html
+++ b/cus_app/templates/orupdate/index.html
@@ -18,6 +18,13 @@
     <p>
     If "Sign-off & Approve" button appears, by clicking it, you can sign it off, and also approve that obsid. You will receive a confirmation email of the submission. 
     </p>
+    <p>
+    The "Discard" button appears if there are any edit sign-off columns remaining, and is removed when all the edits on a revision have been made and it is ready for Usint verification.
+    <br/>The "Discard" button should be used to clear "out-of-date" entries from the Target Parameter Status Page by recording the unsigned columns as "N/A" in the database.
+    </p>
+    <p>
+    Any sign-off, verification, or discard action can be reversed by the user in the Remove Accidental Submission Page.
+    </p>
 <!-- -->
 <!-- form start here -->
 <!-- -->

--- a/cus_app/templates/orupdate/index.html
+++ b/cus_app/templates/orupdate/index.html
@@ -99,7 +99,7 @@
         <tr><th colspan=7>&#160;</th></tr>
     {% endif %}
 <!-- -->
-<!-- Closed ObsIds -->
+<!-- Closed and Discarded ObsIds -->
 <!-- -->
     {% for ent in cdata %}
         {{ data_row(ent, current_user) }}

--- a/cus_app/templates/orupdate/macros.html
+++ b/cus_app/templates/orupdate/macros.html
@@ -48,22 +48,18 @@
 <!-- -->
             {% if data[4] != 'NA' and data[5] != 'NA' and data[6] != 'NA' and data[7] != 'NA' %}
                 {{ cellset(data[8], data[0], 'verify', current_user)  }}
-            {% else %}
-            <p style='color:red;'>Not Ready To Verify</p>
-            {% endif %}
 <!-- -->
-<!-- if higher revision is open or already signed-off, show "Discard" button -->
+<!-- if the entry is not ready for verification, but we want to discard remaining sign-offs, then render the the discard button-->
 <!-- -->
-            {% if data[-1][1] != 0 or data[-1][0] == 2 %}
+            {% elif ((data[4] == 'NA') or (data[5] == 'NA') or (data[6] == 'NA') or (data[7] == 'NA')) and (data[8] == 'NA') and ('admin' in current_user.groups_string or 'usint' in current_user.groups_string) %}
+                <p style='color:red;'>Not Ready To Verify</p>
                 {% set cname = 'discard_' + data[0] %}
-                
-                <br>
                 <input type='submit' name='{{ cname }}' value='Discard'>
-                
+            {% endif %}
 <!-- -->
 <!-- if all others are signed-off, show Signoff & Approve button -->
 <!-- -->
-            {% elif (data[4] != 'NA') and (data[5] != 'NA') and (data[6] != 'NA') and (data[7] != 'NA') and (data[8] == 'NA') and ('admin' in current_user.groups_string or 'usint' in current_user.groups_string) %}
+            {% if (data[4] != 'NA') and (data[5] != 'NA') and (data[6] != 'NA') and (data[7] != 'NA') and (data[8] == 'NA') and ('admin' in current_user.groups_string or 'usint' in current_user.groups_string) %}
                 {% set name = 'approve_' + data[0] %}
                 <br>
                 <input type='submit' name='{{ name }}' value='Sign-off & Approve'>

--- a/cus_app/templates/orupdate/macros.html
+++ b/cus_app/templates/orupdate/macros.html
@@ -52,15 +52,14 @@
             <p style='color:red;'>Not Ready To Verify</p>
             {% endif %}
 <!-- -->
-<!-- if higher revision is open or already signed-off, show "Close" button -->
+<!-- if higher revision is open or already signed-off, show "Discard" button -->
 <!-- -->
             {% if data[-1][1] != 0 or data[-1][0] == 2 %}
-                {% set cname = 'close_' + data[0] %}
-                <!--NOTE Turning off close button until we can understnad who shoudl have access.-->
-                <!--
+                {% set cname = 'discard_' + data[0] %}
+                
                 <br>
-                <input type='submit' name='{{ cname }}' value='Close'>
-                -->
+                <input type='submit' name='{{ cname }}' value='Discard'>
+                
 <!-- -->
 <!-- if all others are signed-off, show Signoff & Approve button -->
 <!-- -->


### PR DESCRIPTION
This PR implements a Discard button into the Target Parameter Status Page which removes "out-of-date" revisions from the page by marking the unsigned edit columns with an "N/A" marker and filling in the Usint Verification Column.