### PR TITLE
Refactor logging

### DIFF
--- a/cus_app/__init__.py
+++ b/cus_app/__init__.py
@@ -142,7 +142,4 @@ def create_app(config_class=DevConfig):
         app.logger.addHandler(file_handler)
 
         app.logger.setLevel(logging.INFO)
-        app.logger.info('Ocat Data startup')
-        
-
     return app

--- a/cus_app/emailing.py
+++ b/cus_app/emailing.py
@@ -69,10 +69,10 @@ def send_email(subject, sender, recipients, text_body, bcc=''):
 
     if bcc:
         message = f"To:{recipients}\nCC:{bcc}\nSubject:{subject}\n{text_body}"
-        cmd = f"echo '{message}' | sendmail {recipients}"
+        cmd = f"echo '{message}' | sendmail -t"
     else:
         message = f"To:{recipients}\nSubject:{subject}\n{text_body}"
-        cmd = f"echo '{message}' | sendmail {recipients}"
+        cmd = f"echo '{message}' | sendmail -t"
     os.system(cmd)
 
 #--------------------------------------------------------------

--- a/cus_app/emailing.py
+++ b/cus_app/emailing.py
@@ -39,6 +39,11 @@ def send_email(subject, sender, recipients, text_body, bcc=''):
 #--- if this is a test say so
 #
     if current_app.config['DEVELOPMENT']:
+        print(f"App in Development. Interrupting the following email to send to testing user instead.\n\
+              Subject: {subject}\n\
+              Recipients: {recipients}\n\
+              BCC: {bcc}\n\
+              CUS: {cus}\n")
         subject    = 'TEST!!!: ' + subject 
         cus        = ''
         recipients = current_user.email

--- a/cus_app/express/routes.py
+++ b/cus_app/express/routes.py
@@ -69,6 +69,7 @@ def before_request():
 @bp.route('/',      methods=['GET', 'POST'])
 @bp.route('/index', methods=['GET', 'POST'])
 def index():
+    current_app.logger.info(f"Opening Express")
 #
 #--- showing the status of input obsids (page 2)
 #

--- a/cus_app/models.py
+++ b/cus_app/models.py
@@ -45,6 +45,7 @@ def register_user():
     
     user = User.query.filter_by(username=username).first()
     login_user(user)
+    current_app.logger.info(f"Login User: {username}")
 
 #----------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------

--- a/cus_app/ocatdatapage/send_notifications.py
+++ b/cus_app/ocatdatapage/send_notifications.py
@@ -19,7 +19,6 @@ import cus_app.emailing                             as email
 #
 basedir = os.path.abspath(os.path.dirname(__file__))
 sender       = 'cus@cfa.harvard.edu'
-bcc          = 'cus@cfa.harvard.edu'
 #
 #--- closing of email text
 #
@@ -83,12 +82,9 @@ def hrc_si_notification(obsids_list, rev_dict):
     notify hrc about hrc si mode change
     input:  obsids_list --- a list of obsids
             rev_dict    --- a dict of <obsid> <--> <revision #>
-    output: email sent ot hrc
+    output: email sent to hrc
     """
-    if current_app.config['DEVELOPMENT']:
-        recipient = current_user.email             
-    else:
-        recipient = 'hrcdude@cfa.harvard.edu'
+    recipient = 'hrcdude@cfa.harvard.edu'
 
     if len(obsids_list) > 1:
         obsid   = obsids_list[0]
@@ -110,11 +106,7 @@ def hrc_si_notification(obsids_list, rev_dict):
         text    = text + current_app.config['HTTP_ADDRESS'] + 'chkupdata/' + str(obsid) + '.' + rev_dict[obsid]  + '\n'
 
     text = text + mail_end
-
-    if current_app.config['DEVELOPMENT']:
-        email.send_email(subject, sender, recipient, text)
-    else:
-        email.send_email(subject, sender, recipient, text, bcc=bcc)
+    email.send_email(subject, sender, recipient, text)
 
 #-----------------------------------------------------------------------------------------------
 #-- arcops_notification: sending arcops about multiple obsid submission                       --
@@ -126,13 +118,9 @@ def arcops_notification(o_list, rev_dict, changed_params):
     input:  o_list          --- a list of obsids
             rev_dict        --- a dict of <obsid> <--> <rev #>
             changed_param   --- a text of a list of parameter values which were updated
-    output: email sent to arcorp
+    output: email sent to arcops
     """
-    if current_app.config['DEVELOPMENT']:
-        recipient = current_user.email
-    else:
-        recipient = 'arcops@cfa.harvard.edu'
-
+    recipient = 'arcops@cfa.harvard.edu'
     subject   = 'Multiple Obsids Are Submitted for Parameter Changes'
 
     text   = 'A USINT user (' + current_user.email + ') '
@@ -151,11 +139,7 @@ def arcops_notification(o_list, rev_dict, changed_params):
     ctext = ctext.replace(' changed from ', ':     ')
 
     text  = text + ctext + mail_end
-
-    if current_app.config['DEVELOPMENT']:
-        email.send_email(subject, sender, recipient, text)
-    else:
-        email.send_email(subject, sender, recipient, text, bcc=bcc)
+    email.send_email(subject, sender, recipient, text)
 
 #-----------------------------------------------------------------------------------------------
 #-- check_mp_notes: sending notification to MP                                                --
@@ -245,24 +229,15 @@ def check_mp_notes(mp_note, rev_dict):
 #--- sending email to MP
 #
     if mtext != '':
-        if current_app.config['DEVELOPMENT']:
-            recipient = current_user.email 
-            email.send_email(msubject, sender, recipient, mtext)
-
-        else:
-            recipient = 'mp@cfa.harvard.edu'
-            email.send_email(msubject, sender, recipient, mtext, bcc=bcc)
+        recipient = 'mp@cfa.harvard.edu'
+        email.send_email(msubject, sender, recipient, mtext)
 #
 #--- sending email to POC
 #
     if ptext != '':
         recipient = current_user.email 
         ptext     = ptext + '\n\n Please contact mp@cfa.harvard.edu, if you have not done so.\n\n'
-
-        if current_app.config['DEVELOPMENT']:
-            email.send_email(psubject, sender, recipient, ptext)
-        else:
-            email.send_email(psubject, sender, recipient, ptext, bcc=bcc)
+        email.send_email(psubject, sender, recipient, ptext)
 
 #-----------------------------------------------------------------------------------------------
 #-- send_other_notification: send a short notification for asis, remove, and clone case       --
@@ -307,11 +282,7 @@ def send_other_notification(asis, obsid, obsids_list):
         text = 'A split request for ' + obsid + ' is submitted.\n'
 
     text = text + mail_end
-
-    if current_app.config['DEVELOPMENT']:
-        email.send_email(subject, sender, recipient, text)
-    else:
-        email.send_email(subject, sender, recipient, text, bcc=bcc)
+    email.send_email(subject, sender, recipient, text)
 
 #-----------------------------------------------------------------------------------------------
 #-- send_too_notification: notify arcops about a fast too observation parameter update        --
@@ -343,13 +314,8 @@ def send_too_notification(ct_dict, asis, rev_dict):
         text  = text + mail_end
  
         subject = otype.upper() + ' observation ' + str(obsid) + ' parameter updates'
-
-        if current_app.config['DEVELOPMENT']:
-            recipient = current_user.email
-            email.send_email(subject, sender, recipient, text)
-        else:
-            recipient = 'arcops@cfa.harvard.edu'
-            email.send_email(subject, sender, recipient, text, bcc=bcc)
+        recipient = 'arcops@cfa.harvard.edu'
+        email.send_email(subject, sender, recipient, text)
 
 #-----------------------------------------------------------------------------------------------
 #-- find_rev_no: create a dict of obsid <--> updated revision #                              ---

--- a/cus_app/ocatdatapage/update_data_record_file.py
+++ b/cus_app/ocatdatapage/update_data_record_file.py
@@ -631,7 +631,6 @@ def send_clone_remove_notification(ct_dict, obsidrev, asis):
     """
     sender    = 'cus@cfa.harvard.edu'
     recipient = current_user.email
-    bcc       = 'cus@cfa.harvard.edu'
     obsid     = str(ct_dict['obsid'][-1])
 #
 #--- notification of Ocat Data Result to POC
@@ -646,11 +645,7 @@ def send_clone_remove_notification(ct_dict, obsidrev, asis):
     elif asis == 'remove':
         subject = subject + ' (Remove Request)'
         text    = obsid + ' was removed from cus_approved list on your request.\n'
-
-    if current_app.config['DEVELOPMENT']:
-        email.send_email(subject, sender, recipient, text)
-    else:
-        email.send_email(subject, sender, recipient, text, bcc=bcc)
+    email.send_email(subject, sender, recipient, text)
 
 #-----------------------------------------------------------------------------------------------
 #-- create_compare_line: create a line to display changed parameter value                     --

--- a/cus_app/orupdate/routes.py
+++ b/cus_app/orupdate/routes.py
@@ -132,11 +132,21 @@ def read_status_data():
             mtime   --- the last file modified time stamp in Chandra Time
             poc_dict    --- a dict of <obsidrev> <---> <poc>
     """
-    #
-    #--- Main database file
-    #
+#
+#--- Main database file
+#
     ufile = os.path.join(current_app.config['OCAT_DIR'], 'updates_table.list')
-    data  = ocf.read_data_file(ufile)
+#
+#--- if the file is locked sleep up to 10 sec
+#
+    chk    = ocf.sleep_while_locked(ufile)
+    if chk:
+        lock   = threading.Lock()
+        with lock:
+            with open(ufile) as f:
+                data = [line.strip() for line in f.readlines()]
+    else:
+        current_app.logger.info(f'Something went wrong and cannot open "{ufile}"')
     data.reverse()
 #
 #--- find out the last file modification time

--- a/cus_app/orupdate/routes.py
+++ b/cus_app/orupdate/routes.py
@@ -72,6 +72,7 @@ def before_request():
 @bp.route('/',      methods=['GET', 'POST'])
 @bp.route('/index', methods=['GET', 'POST'])
 def index():
+    current_app.logger.info(f"Opening Orupdate")
     user         = current_user.username
 #
 #--- odata --- a list of open data

--- a/cus_app/orupdate/routes.py
+++ b/cus_app/orupdate/routes.py
@@ -242,7 +242,7 @@ def check_status(line):
                         <acis si sign off status>
                         <hrc si sign off status>
                         <verified by>
-                        [a list of note section indicator (see blow)]
+                        [a list of note section indicator (see below)]
     """
     atemp    = re.split('\t+', line)
     obsidrev = atemp[0]
@@ -325,8 +325,8 @@ def update_notes(odata, c_dict, h_dict, r_dict):
     """
     create a content of the note section
     input:  odata   --- a list of lists of data; the note section is the last part
-                    <bsidrev open>,<higher rev signed-off>,[<other comments>], 
-                    <color>, <new comment?>, <a large ccoordindate shift?>]
+                    <obsidrev open>,<higher rev signed-off>,[<other comments>], 
+                    <color>, <new comment?>, <a large coordindate shift?>]
             c_dict  --- a dict of <obsid> <---> <rev # still open>
             h_dict  --- a dict of <obsid.rev> <---> <rev # of highest signoff obsid.rev>
                                                      in string format
@@ -792,7 +792,7 @@ def approve_obsid(obsidrev):
     input:  obsidrev    --- <obsid>.<rev#>
     output: <ocat_dir>/approve
             <ocat_dir>/updates/<obsid>.<rev# + 1>
-            various email send out 
+            various emails sent out 
     """
     asis  = 'asis'
     user  = current_user.username
@@ -824,10 +824,9 @@ def check_too_ddt(obsidrev, colname, odata, poc=''):
             colname     --- name of the current column; either gen or si
             odata       --- a list of lists of data of each obsidrev
             poc         --- poc ID
-    output: email sendt out
+    output: email sent out
     """
     sender  = 'cus@cfa.harvard.edu'
-    bcc     = 'cus@cfa.harvard.edu'
 #
 #--- get the type of observation and the instrument of obsid
 #
@@ -875,11 +874,7 @@ def check_too_ddt(obsidrev, colname, odata, poc=''):
                 poc_list  = ocf.read_poc_list(poc)
                 recipient = poc_list[0][2]
             
-            if current_app.config['DEVELOPMENT']:
-                recipient = current_user.email
-                email.send_email(subject, sender, recipient, text)
-            else:
-                email.send_email(subject, sender, recipient, text, bcc=bcc)
+            email.send_email(subject, sender, recipient, text)
 #
 #--- acis/hrc si mode column signed off
 #
@@ -903,11 +898,7 @@ def check_too_ddt(obsidrev, colname, odata, poc=''):
                 recipient = poc_list[0][2]
             
 
-            if current_app.config['DEVELOPMENT']:
-                recipient = current_user.email
-                email.send_email(subject, sender, recipient, text)
-            else:
-                email.send_email(subject, sender, recipient, text, bcc=bcc)
+            email.send_email(subject, sender, recipient, text)
 
 #----------------------------------------------------------------------------------
 #-- read_status: find gen and si mode status of a given <obsidrev>               --
@@ -919,7 +910,7 @@ def read_status(obsidrev, odata):
     input:  obsidrev    --- <obsid>.<rev>
             odata       --- a list of lists of data of each obsidrev
     output: gen         --- general status
-            si          --- aics/hrc si mode status
+            si          --- acis/hrc si mode status
     """
     gen  = 'NA'
     si   = 'NA'

--- a/cus_app/rm_submission/routes.py
+++ b/cus_app/rm_submission/routes.py
@@ -67,6 +67,7 @@ def before_request():
 @bp.route('/',      methods=['GET', 'POST'])
 @bp.route('/index', methods=['GET', 'POST'])
 def index():
+    current_app.logger.info(f"Opening Remove Submission")
 #
 #--- data:      a list form of updates_table.list
 #--- s_dict:    a dict of <obsid.rev> <--> <data info> for a given user

--- a/cus_app/rm_submission/routes.py
+++ b/cus_app/rm_submission/routes.py
@@ -219,7 +219,7 @@ def update_data_tables(form, data):
     """
     modifiy updates_table.list and possibley approved list
     input;  form    --- form data
-            data    --- a list format of udpates_table.list
+            data    --- a list format of updates_table.list
     output: updated <ocat_dir>/updates_table.list
                     <ocat_dir/approved
     """
@@ -432,9 +432,4 @@ def send_notification(obsid):
     text      = 'Remove Accidental Submission Page removed ' + str(obsid) 
     text      = text + ' from cus_approved list.\n'
 
-    if current_app.config['DEVELOPMENT']:
-        email.send_email(subject, sender, recipient, text)
-    else:
-        email.send_email(subject, sender, recipient, text, bcc=bcc)
-
-    
+    email.send_email(subject, sender, recipient, text)

--- a/cus_app/scheduler/routes.py
+++ b/cus_app/scheduler/routes.py
@@ -74,6 +74,7 @@ def before_request():
 @bp.route('/',      methods=['GET', 'POST'])
 @bp.route('/index', methods=['GET', 'POST'])
 def index():
+    current_app.logger.info(f"Opening Scheduler")
     """
     schedule data table content:
             <user full name>


### PR DESCRIPTION
Improvements in the logging command calls for the ocat log files to be more informative. This PR also updates the configuration of the send mail command to the latest "-t" option usage as well as altering all send_email function commands to be passed their live version of recipients. In this way, we can then print out the intended recipient information in a testing scenario before overwriting the recipient information with the testing user email.