### PR TITLE
ACIS SI mode signoff on unrelated parameter changes.

### DIFF
--- a/cus_app/ocatdatapage/update_data_record_file.py
+++ b/cus_app/ocatdatapage/update_data_record_file.py
@@ -471,9 +471,6 @@ def update_status_data_file(ct_dict, user, asis, data, obsidrev):
             if len(acis_list) > 0 or len(awin_list) > 0:
                 acis_si = 'NA'
 
-            elif ct_dict['si_mode'][-1] in ['', None, 'None', 'Null', 'NULL']:
-                acis_si = 'NA'
-
             else:
 #
 #--- coordinate change happens, acis si mode needs to be reviewed


### PR DESCRIPTION
By default, a parameter change on an obsid without a defined SI mode would require an ACIS SI mode signoff. This results in an unnecessary workload on the ACIS team to check on an observation without yet being ready to identify an SI mode for its configuration. The requirement is now removed.