### PR TITLE
dotenv file config change.

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,9 +1,15 @@
 import os
 from datetime import timedelta
 import binascii
+from dotenv import dotenv_values
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
-
-#os.environ should be filled with environment variables in the calling flask app creation script which calls the config object.
+#
+#--- configuration dotfiles settings
+#
+if os.environ.get('FLASK_RUN_FROM_CLI') == 'true':
+    file_config = dotenv_values("/data/mta4/CUS/Data/Env/.localhostenv")
+else:
+    file_config = dotenv_values("/data/mta4/CUS/Data/Env/.cxcweb-env")
 
 #----------------------------------------------------------------------------------------
 #----------------------------------------------------------------------------------------
@@ -12,8 +18,8 @@ BASEDIR = os.path.abspath(os.path.dirname(__file__))
 class Config(object):
 
     DEBUG      = True
-    SEND_ERROR_EMAIL = os.environ.get('SEND_ERROR_EMAIL') or False
-    HTTP_ADDRESS = os.environ.get('HTTP_ADDRESS')
+    SEND_ERROR_EMAIL = file_config.get('SEND_ERROR_EMAIL') or False
+    HTTP_ADDRESS = file_config.get('HTTP_ADDRESS')
 #
 #--- application directory
 #
@@ -22,12 +28,12 @@ class Config(object):
 #
 #--- database and csrf need secret_key
 #
-    #SECRET_KEY = os.environ.get('SECRET_KEY')
+    #SECRET_KEY = file_config.get('SECRET_KEY')
     SECRET_KEY = binascii.b2a_hex(os.urandom(15)).decode()
 #
 #--- database
 #
-    SQLALCHEMY_DATABASE_URI = os.environ.get('DATABASE_URL') or \
+    SQLALCHEMY_DATABASE_URI = file_config.get('DATABASE_URL') or \
         'sqlite:////data/mta4/CUS/Data/Users/app.db'
     SQLALCHEMY_TRACK_MODIFICATIONS = False
 #
@@ -38,12 +44,12 @@ class Config(object):
 #
 #--- mail (SMTPHandler future implementation)
 #
-    MAIL_SERVER     = os.environ.get('MAIL_SERVER')
-    MAIL_PORT       = int(os.environ.get('MAIL_PORT') or 25)
-    MAIL_USE_TLS    = os.environ.get('MAIL_USE_TLS') is not None
+    MAIL_SERVER     = file_config.get('MAIL_SERVER')
+    MAIL_PORT       = int(file_config.get('MAIL_PORT') or 25)
+    MAIL_USE_TLS    = file_config.get('MAIL_USE_TLS') is not None
     MAIL_USE_SSL    = True
-    MAIL_USERNAME   = os.environ.get('MAIL_USERNAME')
-    MAIL_PASSWORD   = os.environ.get('MAIL_PASSWORD')
+    MAIL_USERNAME   = file_config.get('MAIL_USERNAME')
+    MAIL_PASSWORD   = file_config.get('MAIL_PASSWORD')
     TEST_MAIL       = False
     ADMINS          = ['william.aaron@cfa.harvard.edu']
 #
@@ -69,7 +75,7 @@ class Config(object):
 
 class ProdConfig(Config):
     DEBUG    = False
-    SEND_ERROR_EMAIL = os.environ.get('SEND_ERROR_EMAIL') or True
+    SEND_ERROR_EMAIL = file_config.get('SEND_ERROR_EMAIL') or True
     DEVELOPMENT = False
 #
 #--- Live Directory Settings
@@ -85,8 +91,8 @@ class ProdConfig(Config):
 class DevConfig(Config):
     ENV         = 'development'
     DEVELOPMENT = True
-    if os.environ.get('TEST_MAIL') is not None:
-        TEST_MAIL = os.environ.get('TEST_MAIL')
+    if file_config.get('TEST_MAIL') is not None:
+        TEST_MAIL = file_config.get('TEST_MAIL')
     SECRET_KEY = 'secret_key_for_test'
     PERMANENT_SESSION_LIFETIME   = timedelta(minutes=60)
 

--- a/localhost
+++ b/localhost
@@ -1,18 +1,26 @@
 #!/bin/tcsh
-#Commands to run Ocat Flask App (cus_app) on localhost in dev configuration
+#Commands to run Ocat Flask App (cus_app) on localhost in dev configuration.
 
 #As of 06/23/24, web-cxc, Ska3/flight, and MTA PyUsint all use a version of Python 3.11, All of these must be compatible versions.
 #Therefore, if one of these three upgrades to Python 3.12, then all must be upgraded.
 #setenv PYTHONPATH "/proj/sot/ska3/flight/lib:/proj/sot/ska3/flight/lib/python3.11/site-packages:/data/mta4/Script/Python3.11:/data/mta4/Script/Python3.11/lib/python3.11/site-packages"
 #setenv PYTHONPATH "/proj/sot/ska3/flight/lib:/proj/sot/ska3/flight/lib/python3.11/site-packages:/data/mta4/Script/PyUsint:/data/mta4/Script/PyUsint/lib/python3.11/site-packages"
 
-#As of 01/28/25, The Ocat Flask Application will be supported by one of three Usint python conda environments instead of using an extensions approach.
+#As of 01/28/25, The Ocat Flask Application will be supported by one of three Usint python conda environments instead of using an extensions approach
+#which involves setting the PYTHONPATH variable.
 #To retain MTA usage, we source from the ska3-cus-r2d2-v environment specifically.
 source /data/mta4/CUS/ska3-cus-r2d2-v/bin/ska_envs.csh
 
-#These two environment variables are instantiated before the apache web server httpd process is called.
-#This is required for the Sybase python library sybpydb to function.
-setenv LD_LIBRARY_PATH "/soft/SYBASE16.0/OCS-16_0/lib"
+#The following two environment variables are instantiated before the apache web server httpd process is called.
+
+#LD_LIBRARY_PATH is required for the python instance to use the Linux ld linker to connect certain Cython libraries.
+#While a machine running a localhost test might have some desired libraries in their /lib or /usr/lib directories,
+#we override the LD_LIBRARY_PATH setting sourced from the ska_envs.csh script to explicitly prioritize the packages
+#which would be used by the Apache server process to correctly test it.
+#As of 02/05/25, This pathing is located in the httpd-<server_name>-env files.
+setenv LD_LIBRARY_PATH "/soft/SYBASE16.0/OCS-16_0/lib:/proj/servers/python/ska3-cxc-r2d2-v/lib"
+
+#Sybase determines the Sybase Version as located in the 
 setenv SYBASE "/soft/SYBASE16.0"
 
 #For running in an Apache Web server, the python script should have no file extension name so that URL's are clean.

--- a/localhostMAIL
+++ b/localhostMAIL
@@ -1,18 +1,26 @@
 #!/bin/tcsh
-#Commands to run Ocat Flask App (cus_app) on localhost in dev configuration
+#Commands to run Ocat Flask App (cus_app) on localhost in dev configuration.
 
 #As of 06/23/24, web-cxc, Ska3/flight, and MTA PyUsint all use a version of Python 3.11, All of these must be compatible versions.
 #Therefore, if one of these three upgrades to Python 3.12, then all must be upgraded.
 #setenv PYTHONPATH "/proj/sot/ska3/flight/lib:/proj/sot/ska3/flight/lib/python3.11/site-packages:/data/mta4/Script/Python3.11:/data/mta4/Script/Python3.11/lib/python3.11/site-packages"
 #setenv PYTHONPATH "/proj/sot/ska3/flight/lib:/proj/sot/ska3/flight/lib/python3.11/site-packages:/data/mta4/Script/PyUsint:/data/mta4/Script/PyUsint/lib/python3.11/site-packages"
 
-#As of 01/28/25, The Ocat Flask Application will be supported by one of three Usint python conda environments instead of using an extensions approach.
+#As of 01/28/25, The Ocat Flask Application will be supported by one of three Usint python conda environments instead of using an extensions approach
+#which involves setting the PYTHONPATH variable.
 #To retain MTA usage, we source from the ska3-cus-r2d2-v environment specifically.
 source /data/mta4/CUS/ska3-cus-r2d2-v/bin/ska_envs.csh
 
-#These two environment variables are instantiated before the apache web server httpd process is called.
-#This is required for the Sybase python library sybpydb to function.
-setenv LD_LIBRARY_PATH "/soft/SYBASE16.0/OCS-16_0/lib"
+#The following two environment variables are instantiated before the apache web server httpd process is called.
+
+#LD_LIBRARY_PATH is required for the python instance to use the Linux ld linker to connect certain Cython libraries.
+#While a machine running a localhost test might have some desired libraries in their /lib or /usr/lib directories,
+#we override the LD_LIBRARY_PATH setting sourced from the ska_envs.csh script to explicitly prioritize the packages
+#which would be used by the Apache server process to correctly test it.
+#As of 02/05/25, This pathing is located in the httpd-<server_name>-env files.
+setenv LD_LIBRARY_PATH "/soft/SYBASE16.0/OCS-16_0/lib:/proj/servers/python/ska3-cxc-r2d2-v/lib"
+
+#Sybase determines the Sybase Version as located in the 
 setenv SYBASE "/soft/SYBASE16.0"
 
 #For running in an Apache Web server, the python script should have no file extension name so that URL's are clean.

--- a/usint
+++ b/usint
@@ -1,29 +1,24 @@
 import sys, os
-from dotenv import load_dotenv
-
+from dotenv import dotenv_values
 #
-#--- Environment Variable Settings
+#--- Configuration Dotfiles Settings
 #
 if os.environ.get('FLASK_RUN_FROM_CLI') == 'true':
-    load_dotenv("/data/mta4/CUS/Data/Env/.localhostenv")
-    #os.environ["SECRET_KEY"] = 'secret_key_for_test'
+    file_config = dotenv_values("/data/mta4/CUS/Data/Env/.localhostenv")
 else:
-    load_dotenv("/data/mta4/CUS/Data/Env/.cxcweb-env")
-    #load_dotenv("/data/mta4/CUS/Data/Env/.secret_key")
-
+    file_config = dotenv_values("/data/mta4/CUS/Data/Env/.cxcweb-env")
 #
 #--- Path Settings
 #
 #For finding the application scripts in directory where this cus script is located
 sys.path.insert(0,f"{os.path.dirname(os.path.realpath(__file__))}")
 sys.path.insert(1,f"{os.path.dirname(os.path.realpath(__file__))}/cus_app")
-if os.getenv('EXTRA_PATHS') is not None:
-    EXTRA_PATHS = os.getenv('EXTRA_PATHS')
-else:
-    EXTRA_PATHS = '/soft/SYBASE16.0/OCS-16_0/python/python311_64r/lib'
-for path in EXTRA_PATHS.split(":"):
-    if path not in sys.path:
-        sys.path.append(path)
+sys.path.append('/soft/SYBASE16.0/OCS-16_0/python/python311_64r/lib')
+EXTRA_PATHS = file_config.get('EXTRA_PATHS')
+if file_config.get('EXTRA_PATHS') is None:
+    for path in EXTRA_PATHS.split(":"):
+        if path not in sys.path:
+            sys.path.append(path)
 
 #
 #--- Application Imports
@@ -38,7 +33,7 @@ from config             import Config, ProdConfig, DevConfig
 if os.environ.get('FLASK_RUN_FROM_CLI') == 'true':
     #Running app on local host flask server, run with DevConfig
     application = create_app(DevConfig)
-elif os.environ.get('LIVE_DIR') == os.path.abspath(os.path.dirname(__file__)):
+elif file_config.get('LIVE_DIR') == os.path.abspath(os.path.dirname(__file__)):
     #Run with ProdConfin if script is running in the live web directory, otherwise default to DevConfig
     application = create_app(ProdConfig)
 else:


### PR DESCRIPTION
Change to use dotfiles as a configuration hash rather than settings for the python interpreter itself.

This prevents the always loaded Usint web application from using Usint-only environment variables in the python interpreter itself, saving the scope for more general applications.