### PR TITLE
Cycle 28 Application Changes

### DIFF
--- a/cus_app/ocatdatapage/check_value_range.py
+++ b/cus_app/ocatdatapage/check_value_range.py
@@ -292,7 +292,8 @@ def grating_check(ct_dict, warning_list):
     output: warning_list    --- an updated warning_list
     """
     if ct_dict['grating'][-2] != ct_dict['grating'][-1]:
-        note = 'The grating was updated. This Change requires CDO approval.\n'
+        note = 'The grating was updated. This change requires CDO approval.\n'
+        note = note + '<a href="https://cxc.cfa.harvard.edu/cus/InstrumentChanges.html" target="_blank">Instrument Changes Explanation.</a>\n'
         warning_list.append(note)
 
     return warning_list
@@ -358,6 +359,7 @@ def instrument_check(ct_dict, warning_list):
         note = 'The instrument was changed. '
         note = note + 'You need a CDO approval for this change. If you already have '
         note = note + 'the permission, please indicate so in the comment section.\n'
+        note = note + '<a href="https://cxc.cfa.harvard.edu/cus/InstrumentChanges.html" target="_blank">Instrument Changes Explanation.</a>\n'
 #
 #--- if the instrument is change from acis to hrc or another way around, all parameter values
 #--- of the original instrument are nullified; so notify that, too

--- a/cus_app/templates/index.html
+++ b/cus_app/templates/index.html
@@ -76,10 +76,10 @@ via either the cxc or icxc servers. Links for icxc only are marked with
     <a href="https://icxc.cfa.harvard.edu/uspp/IPPS/cdo_checkoff.php">
     Initial Proposal Parameters Signoff (IPPS) by CDO</a>
     -->
-<li><a href="https://cxc.cfa.harvard.edu/cus/Usint/go_form/AO27.html"> 
-	    Cycle 27 Contact Letter Generator</a>
-(<a href="https://cxc.cfa.harvard.edu/cus/Usint/go_form/AO26.html">26</a>,
-  <a href="https://cxc.cfa.harvard.edu/cus/Usint/go_form/AO25.html">25</a>)
+<li><a href="https://cxc.cfa.harvard.edu/cus/Usint/go_form/AO28.html"> 
+	    Cycle 28 Contact Letter Generator</a>
+(<a href="https://cxc.cfa.harvard.edu/cus/Usint/go_form/AO27.html">27</a>,
+  <a href="https://cxc.cfa.harvard.edu/cus/Usint/go_form/AO26.html">26</a>)
     <ul>
     <li><a href="https://cxc.cfa.harvard.edu/cus/earlycontact.txt">Early contact info</a>
     <li><a href="http://cxc.cfa.harvard.edu/cal/ACISlongLetter.html">Long
@@ -167,14 +167,14 @@ via either the cxc or icxc servers. Links for icxc only are marked with
     How to determine/change ObsVis version</a>
   <li>obsvis.cal files for each Cycle (version):<br>
       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+      <a href="https://cxc.cfa.harvard.edu/soft/obsvis/cycle28/obsvis.cal">
+      28 (1.21)</a>
+      &nbsp;
       <a href="https://cxc.cfa.harvard.edu/soft/obsvis/cycle27/obsvis.cal">
       27 (1.20)</a>
       &nbsp;
       <a href="https://cxc.cfa.harvard.edu/soft/obsvis/cycle26/obsvis.cal">
       26 (1.19)</a>
-      &nbsp;
-      <a href="https://cxc.cfa.harvard.edu/soft/obsvis/cycle25/obsvis.cal">
-      25 (1.18)</a>
 </ul>
 
 </tr>
@@ -215,11 +215,11 @@ via either the cxc or icxc servers. Links for icxc only are marked with
 <li>TOO trigger info:
 <ul>
   <li><font color=red><small>[i]</small></font>
+   <a href="https://icxc.cfa.harvard.edu/uspp/TOO/cycle28_toos.html">
+   TOO trigger criteria (AO28)</a> and related info.
+ <li><font color=red><small>[i]</small></font>
    <a href="https://icxc.cfa.harvard.edu/uspp/TOO/cycle27_toos.html">
    TOO trigger criteria (AO27)</a> and related info.
- <li><font color=red><small>[i]</small></font>
-   <a href="https://icxc.cfa.harvard.edu/uspp/TOO/cycle26_toos.html">
-   TOO trigger criteria (AO26)</a> and related info.
 </ul>
 
   <li><font color=red><small>[i]</small></font>

--- a/cus_app/templates/index.html
+++ b/cus_app/templates/index.html
@@ -101,7 +101,6 @@ via either the cxc or icxc servers. Links for icxc only are marked with
     Express Approval</a> 
 <li><a href="https://cxc.cfa.harvard.edu/cus/Usint/APPROVED">
 	ObsIDs approved for flight</a>
-<li><a href="https://cxc.cfa.harvard.edu/cus/InstrumentChanges.html">Instrument Changes</a>
 
 </ul>
 <center>
@@ -147,7 +146,7 @@ via either the cxc or icxc servers. Links for icxc only are marked with
   <li><a href="https://cxc.cfa.harvard.edu/cus/WhenIsMyObservation.txt">
     How to reply to "Why is my observation taking so long?!"
   <li><a href="https://cxc.cfa.harvard.edu/cus/jointprops.html">
-    Joint proposal "coordination" and contact info
+    Joint proposal "coordination" and contact info</a>
 </ul>
 
 <h2><center>ObsVis and Dither</center></h2>
@@ -231,6 +230,9 @@ via either the cxc or icxc servers. Links for icxc only are marked with
 </a>
 <h2><center>Useful Notes and Sites</center></h2>
 <ul>
+<li><a href="https://cxc.cfa.harvard.edu/cus/InstrumentChanges.html">
+  <b><font color=green>Instrument Changes</font></b>
+</a>
 <li> <a href="http://cxc.cfa.harvard.edu/target_lists/longsched.html">
 	Long-Term Schedule</a> (and <font color=red><small>[i]</small></font>
 <a href="https://icxc.cfa.harvard.edu/mp/lts/lts-current.html">with

--- a/cus_app/templates/index.html
+++ b/cus_app/templates/index.html
@@ -68,11 +68,6 @@ via either the cxc or icxc servers. Links for icxc only are marked with
 
 <ul>
 <li><a href="https://cxc.cfa.harvard.edu/cus/procedures.html">USINT Procedures</a> 
-<!--
-<li><font color=red><small>[i]</small></font>
-    <a href="https://icxc.cfa.harvard.edu/uspp/IPPS/cdo_checkoff.php">
-    Initial Proposal Parameters Signoff (IPPS) by CDO</a>
-    -->
 <li><a href="https://cxc.cfa.harvard.edu/cus/Usint/go_form/AO28.html"> 
 	    Cycle 28 Contact Letter Generator</a>
 (<a href="https://cxc.cfa.harvard.edu/cus/Usint/go_form/AO27.html">27</a>,

--- a/cus_app/templates/index.html
+++ b/cus_app/templates/index.html
@@ -68,9 +68,6 @@ via either the cxc or icxc servers. Links for icxc only are marked with
 
 <ul>
 <li><a href="https://cxc.cfa.harvard.edu/cus/procedures.html">USINT Procedures</a> 
-	<font color=green><b>
-	(No S3-only for AO27)
-	</b></font>
 <!--
 <li><font color=red><small>[i]</small></font>
     <a href="https://icxc.cfa.harvard.edu/uspp/IPPS/cdo_checkoff.php">
@@ -153,7 +150,7 @@ via either the cxc or icxc servers. Links for icxc only are marked with
     Joint proposal "coordination" and contact info</font></b></a>
 </ul>
 
-<h2><center>ObsVis and Dither for Cycle 24+</center></h2>
+<h2><center>ObsVis and Dither</center></h2>
 <ul>
 
   <li><a href="https://cxc.cfa.harvard.edu/cus/ditherSize.txt">
@@ -266,12 +263,7 @@ via either the cxc or icxc servers. Links for icxc only are marked with
    the <a href="https://cxc.cfa.harvard.edu/cus/ACISmodeList">SImode list</a>.
 
    <li>ACIS layout:
-	[<a href="https://cxc.cfa.harvard.edu/cus/ACISlayoutCyc24.png">Cyc24 png</a>] 
-	[<a href="https://cxc.cfa.harvard.edu/cus/acis_flight_focal_plane.png">Cyc23 png</a>] 
-	[<a href="https://cxc.cfa.harvard.edu/cus/ACIS_FP_DETAILED.pdf">Cyc23 pdf +caption</a>]<br>
-    <small>
-    (Cycle 23&#8594;24 aimpoints shift by -16,-16 pixels for I3; -16,0 for S3)
-    </small>
+    [<a href="https://cxc.cfa.harvard.edu/proposer/POG/html/chap6.html#tth_sEc6.1">POG Figure</a>]
 </ul>
 
 <li>

--- a/cus_app/templates/index.html
+++ b/cus_app/templates/index.html
@@ -144,10 +144,10 @@ via either the cxc or icxc servers. Links for icxc only are marked with
 	(<a href="https://groups.google.com/a/cfa.harvard.edu/forum/?hl=en#!members/cus">cus</a>,
 	<a href="https://groups.google.com/a/cfa.harvard.edu/forum/?hl=en#!members/usint">usint</a>, etc.)
 
-  <li><a href="https://cxc.cfa.harvard.edu/cus/WhenIsMyObservation.txt"><b><font color=green>
-    How to reply to "Why is my observation taking so long?!"</font></b></a>
-  <li><a href="https://cxc.cfa.harvard.edu/cus/jointprops.html"><b><font color=green>
-    Joint proposal "coordination" and contact info</font></b></a>
+  <li><a href="https://cxc.cfa.harvard.edu/cus/WhenIsMyObservation.txt">
+    How to reply to "Why is my observation taking so long?!"
+  <li><a href="https://cxc.cfa.harvard.edu/cus/jointprops.html">
+    Joint proposal "coordination" and contact info
 </ul>
 
 <h2><center>ObsVis and Dither</center></h2>
@@ -245,12 +245,12 @@ via either the cxc or icxc servers. Links for icxc only are marked with
 	past and future STS's</a>)
 
 <li><a href="https://cxc.cfa.harvard.edu/soft/cps/Chandra.help.html">
-    <b><font color=green>CPS Help for required proposal fields</font></b></a>
+    CPS Help for required proposal fields
 
 <li><font color=red><small>[i]</small></font>
    <a href="https://icxc.harvard.edu/mp/cgi/docs/wiki.pl?Constraints_Definitions
 ">
-    <b><font color=green>All about constraints</font></b></a>
+    All about constraints
     (Time, Phase, Monitor, Group, Split, etc.)
 
 <li><a href="http://cxc.cfa.harvard.edu/acis/home.html">ACIS Ops Home Page</a>

--- a/cus_app/templates/index.html
+++ b/cus_app/templates/index.html
@@ -104,8 +104,9 @@ via either the cxc or icxc servers. Links for icxc only are marked with
     Express Approval</a> 
 <li><a href="https://cxc.cfa.harvard.edu/cus/Usint/APPROVED">
 	ObsIDs approved for flight</a>
-</ul>
+<li><a href="https://cxc.cfa.harvard.edu/cus/InstrumentChanges.html">Instrument Changes</a>
 
+</ul>
 <center>
     <form>
 <p>

--- a/cus_app/templates/index.html
+++ b/cus_app/templates/index.html
@@ -165,11 +165,8 @@ via either the cxc or icxc servers. Links for icxc only are marked with
     How to determine/change ObsVis version</a>
   <li>obsvis.cal files for each Cycle (version):<br>
       &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
-      <a href="https://cxc.cfa.harvard.edu/soft/obsvis/cycle28/obsvis.cal">
-      28 (1.21)</a>
-      &nbsp;
       <a href="https://cxc.cfa.harvard.edu/soft/obsvis/cycle27/obsvis.cal">
-      27 (1.20)</a>
+      28 and 27 (1.20)</a>
       &nbsp;
       <a href="https://cxc.cfa.harvard.edu/soft/obsvis/cycle26/obsvis.cal">
       26 (1.19)</a>

--- a/cus_app/templates/ocatdatapage/display_parameters.html
+++ b/cus_app/templates/ocatdatapage/display_parameters.html
@@ -110,7 +110,7 @@
             <ul>
             {% for ent in wnote %}
                 {% if ent != '' %}
-                    <li style='color:red;font-size:130%;'>{{ ent }} </li>
+                    <li style='color:red;font-size:130%;'>{{ ent | safe}} </li>
                 {% endif %}
             {% endfor %}
             </ul>


### PR DESCRIPTION
Repath the top level application page to link to Cycle 28 versions of the various support web pages. Note that this does not edit all of the necessary web pages for Usint. This PR merely edits the application source code. This does not edit all files pertaining to Cycle 28.