### PR TITLE
[TUTORIAL] Express Approval Page Value Fix

### DIFF
--- a/cus_app/express/routes.py
+++ b/cus_app/express/routes.py
@@ -277,7 +277,7 @@ def get_obsid_info(obsid):
     try:
         p_dict = rod.read_ocat_data(obsid)
     except:
-        return [obsid, '', '', '', '', ''], 'na'
+        return [obsid, '', '', '', '', ''], 'na', 'na'
 
     info_list   = []
     info_list.append(obsid)


### PR DESCRIPTION
This PR fixes anderror in the express approval page which occurs when a correctly formatted but non-existent obsid is fetched from the OCAT. This is meant to throw an error which returns null values, however the return tuple does not contain all necessary null values.

**NOTE:** This PR is falsified in order to create a tutorial for the Ocat_Flask_App debugging and development workflow. This issue is already resolved in our codebase and so this PR will be closed.